### PR TITLE
Relative linking change to stop Keep page refresh when clicking on note-to-note links

### DIFF
--- a/content.js
+++ b/content.js
@@ -60,7 +60,7 @@ function updateTextBox(textBox, markdownActive) {
     if (markdownActive && !textBox.classList.contains('markdown-active')) {
         textBox.classList.add('markdown-active');
         textBox.dataset.originalHtml = textBox.innerHTML;
-		var parsedContent = marked.parse(textBox.innerTextreplaceAll(']( ', ']('));
+		var parsedContent = marked.parse(textBox.innerText.replaceAll(']( ', ']('));
         textBox.innerHTML = parsedContent.replace(GOOGLE_KEEP_URL_PATTERN, '');
         textBox.contentEditable = 'false';
     }

--- a/content.js
+++ b/content.js
@@ -1,4 +1,6 @@
 const activeNoteSelector = '[contenteditable="true"], .markdown-active';
+const GOOGLE_KEEP_URL_PATTERN = /https:\/\/keep\.google\.com\/(?:u\/0\/)?/g;
+
 
 injectCSS();
 
@@ -58,7 +60,8 @@ function updateTextBox(textBox, markdownActive) {
     if (markdownActive && !textBox.classList.contains('markdown-active')) {
         textBox.classList.add('markdown-active');
         textBox.dataset.originalHtml = textBox.innerHTML;
-        textBox.innerHTML = marked.parse(textBox.innerText);
+		var parsedContent = marked.parse(textBox.innerTextreplaceAll(']( ', ']('));
+        textBox.innerHTML = parsedContent.replace(GOOGLE_KEEP_URL_PATTERN, '');
         textBox.contentEditable = 'false';
     }
 

--- a/content.js
+++ b/content.js
@@ -60,7 +60,7 @@ function updateTextBox(textBox, markdownActive) {
     if (markdownActive && !textBox.classList.contains('markdown-active')) {
         textBox.classList.add('markdown-active');
         textBox.dataset.originalHtml = textBox.innerHTML;
-		var parsedContent = marked.parse(textBox.innerText.replaceAll(']( ', ']('));
+	var parsedContent = marked.parse(textBox.innerText.replaceAll(']( ', ']('));
         textBox.innerHTML = parsedContent.replace(GOOGLE_KEEP_URL_PATTERN, '');
         textBox.contentEditable = 'false';
     }


### PR DESCRIPTION
This change dramatically improves both the speed of Keep note-to-note linking in markdown format and stays consistent with mobile.

With the current extension you can enter Keep note-to-note links like this:
`[Compatibilism](#NOTE/1Olfy8J2l4jIER-Akex7qZMGZvG-GG0yZ3Iz_1moXdZrQjFhOu77oxFccLcCbaPWvtSnuw5C1)`
which stops any Chrome page refresh and reloading of Keep and switches directly to the linked note - which is blazingly fast.  But, when this note is opened on mobile, that link is inactive since mobile cannot render the markdown with the domain header missing.

Using the full url format with the extension like this:
`[Compatibilism](https://keep.google.com/#NOTE/1Olfy8J2l4jIER-Akex7qZMGZvG-GG0yZ3Iz_1moXdZrQjFhOu77oxFccLcCbaPWvtSnuw5C1)`
works on mobile but causes the full Keep page refresh on Chrome for note-to-note linking

This solution - dynamically remove `https://keep.google.com` or `https://keep.google.com/u/0/` headers on all note-to-note urls using this Chrome extension fix to stop the refresh but allow the full link on mobile in raw markdown format.